### PR TITLE
Add @JsonProperty for field layout getter/setter

### DIFF
--- a/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
+++ b/dropwizard-logging/src/main/java/io/dropwizard/logging/AbstractAppenderFactory.java
@@ -235,10 +235,12 @@ public abstract class AbstractAppenderFactory<E extends DeferredProcessingAware>
     }
 
     @Nullable
+    @JsonProperty
     public DiscoverableLayoutFactory<?> getLayout() {
         return layout;
     }
 
+    @JsonProperty
     public void setLayout(@Nullable DiscoverableLayoutFactory<E> layout) {
         this.layout = layout;
     }


### PR DESCRIPTION
###### Problem:
Dropwizard allows customized object mapper. If the customization happens to disable AUTO_DETECT_SETTERS (https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/MapperFeature.html#AUTO_DETECT_SETTERS), it will only consider methods explicitly annotated as setters. Thus layout field cannot be recongized. 

Also, it is not consistent with other properties in the same file. The other setters/getters are all annotated.

###### Solution:
Add @JsonProperty annotation for layout property getter and setter 

###### Result:
<!-- What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution. -->
